### PR TITLE
docs:样式更改

### DIFF
--- a/WXCode/README.md
+++ b/WXCode/README.md
@@ -21,7 +21,8 @@
 
   - 使用 `<view/>、<image/>、<text/>` 等搭建页面结构，绑定数据和交互处理函数
 
-  - ```html
+  - block
+  ```html
     <block wx:for-items="{{logs}}" wx:for-item="log">
       <text class="log-item">{{index + 1}}. {{log}}</text> 
     </block>


### PR DESCRIPTION
markdown 在 GitHub 中渲染样式不一致，导致结构不对